### PR TITLE
Fix query handling in epo id lookup

### DIFF
--- a/dxlepoclient/client.py
+++ b/dxlepoclient/client.py
@@ -271,7 +271,7 @@ class EpoClient(Client):
             Request("/mcafee/service/dxl/svcregistry/query"),
             response_timeout,
             {"serviceType": EpoClient.DXL_SERVICE_TYPE})
-        res_dict = MessageUtils.json_payload_to_dict(res)
+        res_dict = MessageUtils.json_to_dict(res)
 
         ret_ids = set()
         if "services" in res_dict:


### PR DESCRIPTION
In a previous commit, the response handling for the epo id service
registry query was changed to use MessageUtils.json_payload_to_dict
to decode the response. This is incorrect, however, in that the response
is actually a string and not a DXL message, causing an exception to be
thrown when the id lookup is complete. In this commit, the
json_to_dict() method is used instead, which handles the response
properly and avoids the exception.