### PR TITLE
Look for remotes service before commands service

### DIFF
--- a/dxlepoclient/client.py
+++ b/dxlepoclient/client.py
@@ -488,14 +488,15 @@ class EpoClient(Client):
         :raise Exception: If no service matching the unique id is registered
             with the DXL fabric.
         """
-        id_for_commands_service = True
+        id_for_commands_service = False
         if epo_unique_id not in \
-            EpoClient._lookup_epo_commands_service_unique_ids(dxl_client,
-                                                              response_timeout):
-            id_for_commands_service = False
-            if epo_unique_id not in \
-                    EpoClient._lookup_epo_remote_service_unique_ids(dxl_client,
-                                                                    response_timeout):
+            EpoClient._lookup_epo_remote_service_unique_ids(dxl_client,
+                                                            response_timeout):
+            if epo_unique_id in \
+                    EpoClient._lookup_epo_commands_service_unique_ids(
+                            dxl_client, response_timeout):
+                id_for_commands_service = True
+            else:
                 raise Exception("No ePO DXL services are registered with " +
                                 "the DXL fabric for id: " + epo_unique_id)
         return id_for_commands_service
@@ -518,15 +519,15 @@ class EpoClient(Client):
             containing the unique identifiers for the ePO servers that are
             currently exposed to the DXL fabric.
         """
-        ids_for_epo_commands_service = True
-        ret_ids = EpoClient._lookup_epo_commands_service_unique_ids(
+        ids_for_epo_commands_service = False
+        ret_ids = EpoClient._lookup_epo_remote_service_unique_ids(
             dxl_client, response_timeout
         )
         if not ret_ids:
-            ret_ids = EpoClient._lookup_epo_remote_service_unique_ids(
+            ret_ids = EpoClient._lookup_epo_commands_service_unique_ids(
                 dxl_client, response_timeout
             )
-            ids_for_epo_commands_service = False
+            ids_for_epo_commands_service = True
         return ids_for_epo_commands_service, ret_ids
 
     @staticmethod

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -94,6 +94,33 @@ class TestClient(BaseClientTest):
                         EpoClient,
                         dxl_client)
 
+    def test_init_no_unique_id_remote_preferred_to_commands_service(self):
+        with self.create_client(max_retries=0) as dxl_client:
+            dxl_client.connect()
+
+            with MockEpoServer(dxl_client, id_number=0,
+                               use_commands_service=True), \
+                    MockEpoServer(dxl_client, id_number=1,
+                                  use_commands_service=False):
+                epo_client = EpoClient(dxl_client)
+                self.assertEqual(epo_client._epo_unique_id,
+                                 LOCAL_TEST_SERVER_NAME + "1")
+                self.assertIn("core.help", epo_client.help())
+
+    def test_init_same_unique_id_remote_preferred_to_commands_service(self):
+        with self.create_client(max_retries=0) as dxl_client:
+            dxl_client.connect()
+
+            with MockEpoServer(dxl_client, use_commands_service=True,
+                               user_authorized=False), \
+                     MockEpoServer(dxl_client,
+                                   use_commands_service=False):
+                epo_client = EpoClient(dxl_client)
+                self.assertEqual(epo_client._epo_unique_id,
+                                 LOCAL_TEST_SERVER_NAME +
+                                 str(DEFAULT_EPO_SERVER_ID))
+                self.assertIn("core.help", epo_client.help())
+
     def test_lookup_epo_unique_identifiers(self):
         with self.create_client(max_retries=0) as dxl_client:
             dxl_client.connect()


### PR DESCRIPTION
Previously, the client would attempt to use an ePO "commands" service if
both a "remote" and "commands" service were available on the fabric.
Since no commands are authorized by default, a user who has a "remote"
service on the fabric would encounter client failures after upgrading
the ePO server to DXL 5 extensions until authorization is configured for
the commands service.

This commit changes the logic to look for and use a "remote" service
first if both a "remote" and "commands" service are available. This
allows for calls to the remote service to continue to function properly
for backward compatibility on initial upgrade of the ePO server to DXL
5 extensions.