### PR TITLE
Combine commands and remote service ids together during lookup

### DIFF
--- a/dxlepoclient/client.py
+++ b/dxlepoclient/client.py
@@ -490,8 +490,8 @@ class EpoClient(Client):
         """
         id_for_commands_service = False
         if epo_unique_id not in \
-            EpoClient._lookup_epo_remote_service_unique_ids(dxl_client,
-                                                            response_timeout):
+                EpoClient._lookup_epo_remote_service_unique_ids(
+                        dxl_client, response_timeout):
             if epo_unique_id in \
                     EpoClient._lookup_epo_commands_service_unique_ids(
                             dxl_client, response_timeout):
@@ -514,21 +514,20 @@ class EpoClient(Client):
         :param response_timeout: (optional) The maximum amount of time to wait
             for a response
         :return: A ``tuple`` where the first item is a ``bool`` representing
-            whether the returned ids are for "commands" services (``True``) or
-            "remote" services (``False``) and the second item is a ``set``
-            containing the unique identifiers for the ePO servers that are
-            currently exposed to the DXL fabric.
+            whether a "commands" service (``True``) or "remote" service
+            (``False``) should be used. If at least one "remote" service is
+            available, a "remote" service should be used. The second item in
+            the ``tuple`` is a ``set`` containing the unique identifiers for
+            the ePO servers that are currently exposed to the DXL fabric.
         """
-        ids_for_epo_commands_service = False
-        ret_ids = EpoClient._lookup_epo_remote_service_unique_ids(
-            dxl_client, response_timeout
-        )
-        if not ret_ids:
-            ret_ids = EpoClient._lookup_epo_commands_service_unique_ids(
-                dxl_client, response_timeout
-            )
-            ids_for_epo_commands_service = True
-        return ids_for_epo_commands_service, ret_ids
+        epo_remote_service_ids = \
+            EpoClient._lookup_epo_remote_service_unique_ids(dxl_client,
+                                                            response_timeout)
+        epo_command_service_ids = \
+            EpoClient._lookup_epo_commands_service_unique_ids(dxl_client,
+                                                              response_timeout)
+        return not epo_remote_service_ids, \
+            epo_command_service_ids.union(epo_remote_service_ids)
 
     @staticmethod
     def lookup_epo_unique_identifiers(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -94,7 +94,7 @@ class TestClient(BaseClientTest):
                         EpoClient,
                         dxl_client)
 
-    def test_init_no_unique_id_remote_preferred_to_commands_service(self):
+    def test_init_no_unique_id_with_both_remote_and_command_services(self):
         with self.create_client(max_retries=0) as dxl_client:
             dxl_client.connect()
 
@@ -102,10 +102,13 @@ class TestClient(BaseClientTest):
                                use_commands_service=True), \
                     MockEpoServer(dxl_client, id_number=1,
                                   use_commands_service=False):
-                epo_client = EpoClient(dxl_client)
-                self.assertEqual(epo_client._epo_unique_id,
-                                 LOCAL_TEST_SERVER_NAME + "1")
-                self.assertIn("core.help", epo_client.help())
+                self.assertRaisesRegex(
+                    Exception,
+                    "Multiple ePO DXL services are registered.*" +
+                    LOCAL_TEST_SERVER_NAME + '0' + ", " +
+                    LOCAL_TEST_SERVER_NAME + '1',
+                    EpoClient,
+                    dxl_client)
 
     def test_init_same_unique_id_remote_preferred_to_commands_service(self):
         with self.create_client(max_retries=0) as dxl_client:


### PR DESCRIPTION
Previously, a `lookup_epo_unique_identifiers` call would return
either the list of `remote` service ids (if at least one `remote`
service was available) or the list of `commands` service ids (if no
`remote` services were available). The returned list would not
include the superset of available `remote` and `commands` service
ids.

In this commit, the combined list of `remote` and `commands` service
ids is returned for a `lookup_epo_unique_identifiers` call.